### PR TITLE
Enable set scalacExecutablePath from setting view

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,6 @@
 module.exports =
 	configDefaults:
-		scalacExecutablePath: null
+		scalacExecutablePath: ''
 		scalacOptions: '-Xlint'
 
 	activate: -> console.log('activate linter-scalac')


### PR DESCRIPTION
Null config will be ignored by atom.config.

``` javascript
atom.config.setDefaults("test", {a:1, b:"string", c:null})
atom.config.getDefault("test")
=>Object {a: 1, b: "string"}
```

So `scalacExecutablePath` will not appear in setting view

Before
![screen shot 2014-10-27 at 12 46 26 pm](https://cloud.githubusercontent.com/assets/1381907/4788296/1e68d3a4-5db8-11e4-9cb4-e399a3f34622.png)

This PR change setting view like below
![screen shot 2014-10-27 at 6 05 04 pm](https://cloud.githubusercontent.com/assets/1381907/4788329/66b6e678-5db8-11e4-9426-e957dd2d8779.png)
