### PR TITLE
Remove linter-package metadata to resolve #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "linter-scalac",
-  "linter-package": true,
   "main": "./lib/init",
   "version": "0.3.4",
   "description": "Lint Scala on the fly, using scalac. Also possible to use other Scala linters, such as WartRemover, via compiler options.",
@@ -8,5 +7,12 @@
   "license": "MIT",
   "engines": {
     "atom": ">0.90.0"
+  },
+  "providedServices": {
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
+      }
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ $ brew install scala
 $ brew cask install atom
 ```
 ---
-[linter](https://github.com/AtomLinter/Linter):
+[linter](https://github.com/atom-community/linter):
 ```bash
 $ apm install linter
 ```


### PR DESCRIPTION
Resolves the deprecation of the linter-package metadata, as per https://github.com/atom-community/linter/wiki/Migrating-to-the-new-API