### PR TITLE
Fix #20

### DIFF
--- a/lib/linter-scalac.coffee
+++ b/lib/linter-scalac.coffee
@@ -17,6 +17,7 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-scalac.scalacOptions',
       (scalacOptions) =>
         @scalacOptions = scalacOptions
+    @cmd = 'scalac'
 
   deactivate: ->
     @subscriptions.dispose()
@@ -32,7 +33,10 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         args = @scalacOptions.split(' ')
-        command = atom.config.get 'linter-scalac.scalacExecutablePath'
+        if @scalacExecutablePath
+          command = @scalacExecutablePath + '/' + @cmd
+        else
+          command = @cmd
         if helpers.findFile(filePath, '.classpath')
           dotClasspath = helpers.findFile(filePath, '.classpath')
           classpath = fs.readFileSync(dotClasspath).toString().trim()


### PR DESCRIPTION
Previous commit to fix #19 accidentally conflicts with the documentation. The docs say to not include "scalac" in the path and the issue with #19 was that it included it in the path:

```
  "linter-scalac": {
    "scalacExecutablePath": "/Users/evo/.jenv/shims/scalac"
  }
```

This should revert the change.