### PR TITLE
Compile to classpath and Lint all sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 *.log
 node_modules/
+target
+.classpath

--- a/lib/linter-scalac.coffee
+++ b/lib/linter-scalac.coffee
@@ -5,9 +5,19 @@ module.exports =
     scalacExecutablePath:
       type: 'string'
       default: 'scalac'
+      order: 1
     scalacOptions:
       type: 'string'
       default: '-Xlint'
+      order: 2
+    compileClassesToClasspath:
+      type: 'boolean'
+      default: false
+      order: 3
+    compileAllClassesOnLint:
+      type: 'boolean'
+      default: false
+      order: 4
 
   activate: ->
     require('atom-package-deps').install('linter-scalac')
@@ -18,6 +28,14 @@ module.exports =
     @subscriptions.add atom.config.observe 'linter-scalac.scalacOptions',
       (scalacOptions) =>
         @scalacOptions = scalacOptions
+    @subscriptions.add atom.config.observe 'linter-scalac.compileClassesToClasspath',
+      (compileClassesToClasspath) =>
+        @compileClassesToClasspath = compileClassesToClasspath
+        atom.config.set 'linter-scalac.compileAllClassesOnLint', false if not compileClassesToClasspath
+    @subscriptions.add atom.config.observe 'linter-scalac.compileAllClassesOnLint',
+      (compileAllClassesOnLint) =>
+        @compileAllClassesOnLint = compileAllClassesOnLint
+        atom.config.set 'linter-scalac.compileClassesToClasspath', true if compileAllClassesOnLint
 
   deactivate: ->
     @subscriptions.dispose()
@@ -25,20 +43,45 @@ module.exports =
   provideLinter: ->
     helpers = require 'atom-linter'
     fs = require 'fs'
-    regex = 'scala:(?<line>\\d+): (?<type>(error|warning)): (?<message>(.+))'
+    path = require 'path'
+    glob = require 'glob'
+    mkdirp = require 'mkdirp'
+    regex = '(?<file>.+):(?<line>\\d+): (?<type>(error|warning)): (?<message>(.+))'
+    compilerRegex = 'scalac (?<type>(error|warning)): (?<message>(.+))'
     provider =
       grammarScopes: ['source.scala']
-      scope: 'file'
+      scope: if @compileAllClassesOnLint then 'project' else 'file'
       lintOnFly: false
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         args = @scalacOptions.split(' ')
         command = atom.config.get 'linter-scalac.scalacExecutablePath'
-        if helpers.findFile(filePath, '.classpath')
+        matchingProjectPaths = (tmpPath for tmpPath in atom.project.getPaths() when (filePath.replace /\\/g, "/").match ///^#{tmpPath.replace /\\/g, "/"}.+///)
+        throw "No project paths available" unless matchingProjectPaths.length == 1
+        projectPath = matchingProjectPaths[0]
+
+        if helpers.findFile(projectPath, '.classpath')
           dotClasspath = helpers.findFile(filePath, '.classpath')
           classpath = fs.readFileSync(dotClasspath).toString().trim()
-          args.push('-classpath')
-          args.push(classpath)
-        args.push(filePath)
-        return helpers.exec(command, args, {stream: 'stderr'}).then (output) ->
-          return helpers.parse(output, regex, {filePath: filePath})
+
+          args.push '-classpath'
+          args.push "#{classpath}"
+
+          if @compileClassesToClasspath
+            outputPath = classpath.split(path.delimiter)[0]
+            mkdirp.sync outputPath if atom.project.contains(outputPath)
+            args.push '-d'
+            args.push "#{outputPath}"
+
+          if @compileAllClassesOnLint
+            paths = glob.sync("**#{path.sep}*.scala", {'cwd': projectPath})
+            .map (sourcePath) -> "#{projectPath}#{path.sep}#{sourcePath.replace /\//g, path.sep}"
+            .filter (sourcePath) -> filePath isnt sourcePath
+            .map (sourcePath) -> "#{sourcePath}"
+            args = args.concat paths
+
+        args.push "#{filePath}"
+        return helpers.exec command, args, {stream: 'stderr'}
+          .then (output) ->
+            return helpers.parse output, regex
+            .concat helpers.parse output, compilerRegex

--- a/package.json
+++ b/package.json
@@ -10,7 +10,13 @@
   },
   "dependencies": {
     "atom-linter": ">=3.0.0",
-    "atom-package-deps": "^2.0.1"
+    "atom-package-deps": "^2.0.1",
+    "glob": "^6.0.1",
+    "mkdirp": "^0.5.1"
+  },
+  "devDependencies": {
+    "promised-exec": "1.0.1",
+    "rimraf": "^2.4.4"
   },
   "package-deps": [
     "linter"

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,10 @@ Via `config.json`:
   'scalacExecutablePath': 'scalac'
   # Execute `scalac -X` and `scalac -Y` for a handful of useful options.
   'scalacOptions': '-Xlint -P:wartremover:traverser:org.brianmckenna.wartremover.warts.Unsafe'
+  # Write the compiled classes to the location specified in .classpath
+  'compileClassesToClasspath': false
+  # Compile all Scala files in the project on lint.
+  'compileAllClassesOnLint': false
 ```
 
 > <sub>__Note:__ It is also possible to configure linter-scalac via the GUI: `Atom` > `Preferences` > `linter-scalac`</sub>

--- a/spec/fixtures/project1/EntryPoint.scala
+++ b/spec/fixtures/project1/EntryPoint.scala
@@ -1,0 +1,8 @@
+class Foo(foo: String) {
+  def bar() = println(foo)
+}
+
+object Main extends App {
+  val foo = new Foo("test")
+  foo.bar2()
+}

--- a/spec/fixtures/project2/src/main/scala/EntryPoint.scala
+++ b/spec/fixtures/project2/src/main/scala/EntryPoint.scala
@@ -1,0 +1,4 @@
+object Main extends App {
+  val foo = new Foo("test")
+  foo.bar2()
+}

--- a/spec/fixtures/project2/src/main/scala/Foo.scala
+++ b/spec/fixtures/project2/src/main/scala/Foo.scala
@@ -1,0 +1,3 @@
+class Foo(foo: String) {
+  def bar() = println(foo)
+}

--- a/spec/fixtures/project3/src/main/scala/linter/scalac/EntryPoint.scala
+++ b/spec/fixtures/project3/src/main/scala/linter/scalac/EntryPoint.scala
@@ -1,0 +1,6 @@
+package linter.scalac
+
+object Main extends App {
+  val foo = new Foo("test")
+  foo.bar2()
+}

--- a/spec/fixtures/project3/src/main/scala/linter/scalac/Foo.scala
+++ b/spec/fixtures/project3/src/main/scala/linter/scalac/Foo.scala
@@ -1,0 +1,5 @@
+package linter.scalac
+
+class Foo(foo: String) {
+  def bar() = println(foo)
+}

--- a/spec/linter-scalac-spec.coffee
+++ b/spec/linter-scalac-spec.coffee
@@ -1,0 +1,238 @@
+
+# Requires scalac to be installed and on the path. Tests were written on OSX 10.10
+# and verified on Windows 7. If running on Windows, Atom can't be open at the same
+# time as it prevents some of the temp directories being created/torn down.
+
+describe "linter-scalac", ->
+  exec = require 'promised-exec'
+  fs = require 'fs'
+  mkdirp = require 'mkdirp'
+  rm = require 'rimraf'
+  path = require 'path'
+
+  lint = require('../lib/linter-scalac')
+    .provideLinter()
+    .lint
+
+  fixturesPath = "#{__dirname}#{path.sep}fixtures"
+
+  resetPath = (targetPath) ->
+    Promise.resolve rm.sync targetPath
+    .catch (error) -> ;
+
+  getScalaVersion = () ->
+    exec "scalac -version"
+    .catch (versionString) ->
+      (/.+(\d+\.\d+)\..+/.exec versionString.buffer)[1]
+
+  beforeEach ->
+    jasmine.getEnv().defaultTimeoutInterval = 60000
+    waitsForPromise ->
+      atom.packages.activatePackage("linter-scalac")
+
+  describe "the standard behaviour", ->
+
+    it "lints a source file with no dependencies", ->
+      projectPath = "#{fixturesPath}#{path.sep}project1"
+      targetFile = "#{fixturesPath}#{path.sep}project1#{path.sep}EntryPoint.scala"
+      waitsForPromise ->
+        atom.project.setPaths [projectPath]
+        atom.workspace.open projectPath
+        .then () ->
+          atom.workspace.open targetFile
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 1
+
+          expect messages[0].type
+          .toEqual 'error'
+
+          expect messages[0].text
+          .toEqual 'value bar2 is not a member of Foo'
+
+    it "lints a source file with dependencies if the dependencies are already compiled", ->
+      projectPath = "#{fixturesPath}#{path.sep}project2"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}EntryPoint.scala"
+      dependency = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}Foo.scala"
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then (outputPath) ->
+          exec "scalac -d \"#{outputPath}\" -classpath \"#{outputPath}\" \"#{dependency}\""
+        .then () ->
+          atom.project.setPaths [projectPath]
+          atom.workspace.open targetFile
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 1
+
+          expect messages[0].type
+          .toEqual 'error'
+
+          expect messages[0].text
+          .toEqual 'value bar2 is not a member of Foo'
+
+    it "lints a source file with dependencies in packages if the dependencies are already compiled", ->
+      projectPath = "#{fixturesPath}#{path.sep}project3"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}EntryPoint.scala"
+      dependency = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.scala"
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then (outputPath) ->
+          exec "scalac -d \"#{outputPath}\" -classpath \"#{outputPath}\" \"#{dependency}\""
+        .then () ->
+          atom.project.setPaths [projectPath]
+          atom.workspace.open "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}EntryPoint.scala"
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 1
+
+          expect messages[0].type
+          .toEqual 'error'
+
+          expect messages[0].text
+          .toEqual 'value bar2 is not a member of linter.scalac.Foo'
+
+    it "does not usefully lint a source file with dependencies in packages if the dependencies are not compiled", ->
+      projectPath = "#{fixturesPath}#{path.sep}project3"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}EntryPoint.scala"
+      dependency = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.scala"
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then () ->
+          atom.project.setPaths [projectPath]
+          atom.workspace.open targetFile
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 1
+
+          expect messages[0].type
+          .toEqual 'error'
+
+          expect messages[0].text
+          .toEqual 'not found: type Foo'
+
+    it "does not compile files to the classpath", ->
+      projectPath = "#{fixturesPath}#{path.sep}project3"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.scala"
+      outputPath = null
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then () ->
+          atom.project.setPaths [projectPath]
+          atom.workspace.open targetFile
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 0
+
+          expect () ->
+            (fs.statSync "#{outputPath}#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.class").isFile()
+          .toThrow Error("ENOENT: no such file or directory, stat '#{outputPath}#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.class'")
+
+          expect (fs.statSync "#{__dirname}#{path.sep}..#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.class").isFile()
+          .toEqual true
+          "#{__dirname}#{path.sep}..#{path.sep}linter"
+        .then resetPath
+
+  describe "the behaviour that writes to the classpath folder", ->
+
+    it "compiles files to the classpath", ->
+      projectPath = "#{fixturesPath}#{path.sep}project3"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.scala"
+      outputPath = null
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then () ->
+          atom.config.set "linter-scalac.compileClassesToClasspath", true
+          atom.project.setPaths [projectPath]
+          atom.workspace.open targetFile
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 0
+
+          expect (fs.statSync "#{outputPath}#{path.sep}linter#{path.sep}scalac#{path.sep}Foo.class").isFile()
+          .toEqual true
+
+  describe "the behaviour that compiles all classes on lint", ->
+
+    it "lints the active file by compiling all the scala files in the project", ->
+      projectPath = "#{fixturesPath}#{path.sep}project3"
+      targetPath = "#{projectPath}#{path.sep}target"
+      targetFile = "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}EntryPoint.scala"
+      outputPath = null
+
+      waitsForPromise ->
+        resetPath(targetPath)
+        .then getScalaVersion
+        .then (scalaVersion) ->
+          outputPath = "#{targetPath}#{path.sep}scala-#{scalaVersion}#{path.sep}classes"
+          fs.writeFileSync "#{projectPath}#{path.sep}.classpath", outputPath
+          mkdirp outputPath
+          outputPath
+        .then () ->
+          atom.config.set "linter-scalac.compileClassesToClasspath", true
+          atom.config.set "linter-scalac.compileAllClassesOnLint", true
+          atom.project.setPaths [projectPath]
+          atom.workspace.open "#{projectPath}#{path.sep}src#{path.sep}main#{path.sep}scala#{path.sep}linter#{path.sep}scalac#{path.sep}EntryPoint.scala"
+        .then (editor) ->
+          lint editor
+        .then (messages) ->
+          expect messages.length
+          .toEqual 1
+
+          expect messages[0].type
+          .toEqual 'error'
+
+          expect messages[0].text
+          .toEqual 'value bar2 is not a member of linter.scalac.Foo'


### PR DESCRIPTION
## Description

This PR proposes the addition of two new configuration options: **compile to classpath** and **compile all sources on lint**. Tests have also been added the exercise the existing functionality as well as the new.

The effect of the new settings is as follows, given the following Scala source tree:

```
.
├── .classpath
└── src
    └── main
        └── scala
            └── linter
                └── scalac
                    ├── EntryPoint.scala
                    └── Foo.scala
```

#### Current behaviour

With a `.classpath` file specifying some output path linter-scalac lints `Foo.scala` fine as it has no dependencies. However `EntryPoint.scala` imports `Foo.scala` and so will not lint correctly unless `Foo.scala` has been compiled by something else, e.g. `sbt`.

#### Behaviour with new compile to classpath option

If the file `Foo.scala` is linted, it will be compiled to the path specified in `.classpath` + the appropriate package path. This means when `EntryPoint.scala` is linted it can access the compiled definition of `Foo.scala`.

#### Behaviour with new compile all sources option

All of the scala sources files in the current project are compiled on lint giving correct access to all the files.

## Why?

Currently linting is limited to syntax and pre-compiled files. This means depending on external compilation to lint in Atom which isn't the best workflow. Being able to compile to the class path and compile all sources allows for a workflow based only in Atom.

## Are there any problems?

The approach to compiling all classes is unoptimised and `scalac` is not a fast compiler. This means that the new settings are not appropriate for large projects. That's intentional - bigger projects should use something like Scala IDE or IntelliJ, but this change makes Atom friendlier for quick Scala hacking.

## This looks like quite a big change!

Actually not that much has changed - the settings are optional and off by default so the out-of-the-box behaviour does not change. Several tests and associated fixtures have been added which make the change appear larger than it is.