### PR TITLE
Properly declare the member functions

### DIFF
--- a/lib/linter-scalac.js
+++ b/lib/linter-scalac.js
@@ -29,7 +29,7 @@ module.exports = {
     }
   },
 
-  activate: () => {
+  activate() {
     require('atom-package-deps').install();
 
     this.subscriptions = new CompositeDisposable();
@@ -59,11 +59,11 @@ module.exports = {
         }));
   },
 
-  deactivate: () => {
+  deactivate() {
     this.subscriptions.dispose();
   },
 
-  provideLinter: () => {
+  provideLinter() {
     const helpers = require('atom-linter');
 
     const fs = require('fs');


### PR DESCRIPTION
Function declaration using an arrow function in the global scope is invalid, and the cleaner transpilation in Atom v1.16.0 breaks on this method.

See https://github.com/atom/atom/pull/13823#issuecomment-286985411 for details.