### PR TITLE
Specify the package name

### DIFF
--- a/lib/linter-scalac.js
+++ b/lib/linter-scalac.js
@@ -28,7 +28,7 @@ module.exports = {
   },
 
   activate() {
-    require('atom-package-deps').install();
+    require('atom-package-deps').install('linter-scalac');
 
     this.subscriptions = new CompositeDisposable();
 


### PR DESCRIPTION
`atom-package-deps` now _requires_ the package name to be specified.

This was missed in #85.